### PR TITLE
refactor: 키보드 이벤트 switch문 변경 및 취소 이벤트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,26 +25,42 @@ function App() {
     setIsInputFocused(false);
     setElIndexFocused(-1);
   };
-  const inputOnKeyDownHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.nativeEvent.isComposing) return;
-
-    if (searchData.length === 0 || (e.code !== 'ArrowUp' && e.code !== 'ArrowDown')) return;
-    e.preventDefault();
-
-    if (e.code === 'ArrowUp') {
-      if (elIndexFocused <= 0) {
-        setElIndexFocused(searchData.length - 1);
-      } else {
-        setElIndexFocused(prev => prev - 1);
-      }
+  const handleArrowUpKey = () => {
+    if (elIndexFocused <= 0) {
+      setElIndexFocused(searchData.length - 1);
+    } else {
+      setElIndexFocused(prev => prev - 1);
     }
+  };
+  const handleArrowDownKey = () => {
+    if (elIndexFocused === searchData.length - 1) {
+      setElIndexFocused(0);
+    } else {
+      setElIndexFocused(prev => prev + 1);
+    }
+  };
+  const handleEscapeKey = () => {
+    setSearchData([]);
+    setSearchKeyword('');
+    setElIndexFocused(-1);
+  };
+  const inputOnKeyDownHandler = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const keyArr = ['ArrowUp', 'ArrowDown', 'Escape'];
 
-    if (e.code === 'ArrowDown') {
-      if (elIndexFocused === searchData.length - 1) {
-        setElIndexFocused(0);
-      } else {
-        setElIndexFocused(prev => prev + 1);
-      }
+    if (event.nativeEvent.isComposing) return;
+    if (searchData.length === 0 || !keyArr.includes(event.code)) return;
+    event.preventDefault();
+
+    switch (event.key) {
+      case 'ArrowUp':
+        handleArrowUpKey();
+        break;
+      case 'ArrowDown':
+        handleArrowDownKey();
+        break;
+      case 'Escape':
+        handleEscapeKey();
+        break;
     }
   };
   const liMouseOverHandler = (e: React.MouseEvent<HTMLLIElement>) => {


### PR DESCRIPTION
## 개요 :mag:
- keyboard event의 가독성 향상을 위한 리팩토링 진행

## 작업사항 :memo:
- 기존 if 문으로 분기처리를 하던 키보드 이벤트를 switch 문을 이용하여 처리했습니다.
- `includes` 메서드를 이용하여 키보드 이벤트 사용 키 예외 처리

## 테스트 방법(optional)
- 검색 창에 단어를 입력하신 후에 위, 아래 화살표 방향키로 추천 검색어로 제대로 이동하는지 확인하시면 됩니다.
- 검색 창에 단어를 입력하신 후에 esc 키를 눌러 검색 창의 검색어와 추천 검색어 리스트가 초기화 되는지 확인하시면 됩니다.